### PR TITLE
[ci] Uppdatera actions/upload-artifact till v4 (deprecation fix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
         run: npm run build
         
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: frontend-build
           path: dist/


### PR DESCRIPTION
- Byter ut actions/upload-artifact@v3 mot v4 i ci.yml enligt GitHub Actions deprecationskrav
- Löser felmeddelande: 'This request has been automatically failed because it uses a deprecated version of actions/upload-artifact: v3.'
- Ingen annan kodpåverkan